### PR TITLE
Add Aktentaucherin

### DIFF
--- a/ttnconfig/rssfeeds.json
+++ b/ttnconfig/rssfeeds.json
@@ -1217,4 +1217,8 @@
     "url": "https://www.cilip.de/feed/",
     "outlet": "CILIP Institut und Zeitschrift"
   } 
+  {
+    "url": "https://aktentaucherin.de/feed",
+    "outlet": "Aktentaucherin: Die Kanzlei für Informationsfreiheit"
+  }
 ]


### PR DESCRIPTION
This PR adds "Aktentaucherin: Die Kanzlei für Informationsfreiheit" to `rssfeeds.json`.